### PR TITLE
fix lint fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ lint:
 
 .PHONY: lint_fix
 lint_fix:
-	npm run lint --fix
+	npm run lint:fix
 
 .PHONY: new_article
 new_article:


### PR DESCRIPTION
This pull request includes a small change to the `Makefile`. The change modifies the `lint_fix` target to use the correct npm script for fixing linting issues.

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L11-R11): Changed the `lint_fix` target to use `npm run lint:fix` instead of `npm run lint --fix`.