### PR TITLE
update zig install

### DIFF
--- a/books/zig-blockchain/chapter1.md
+++ b/books/zig-blockchain/chapter1.md
@@ -25,7 +25,7 @@ ZigはC言語に近い構文と性能を持ちながらも、メモリセーフ�
 ### Zigのインストール方法
 
 Zig公式サイトから各プラットフォーム向けのバイナリをダウンロードし、パスを通すのが最も手軽な方法です ([Getting Started⚡Zig Programming Language](https://ziglang.org/learn/getting-started/))。Zigはインストールがシンプルで、単一の実行ファイルを好きな場所に置いてパスを設定すれば利用できます。
-インストール後、ターミナル/コマンドプロンプトで `zig version` を実行し、バージョンが表示されれば成功です。
+インストール後、ターミナル/コマンドプロンプトで `zig version` を実行し、バージョンが表示されれば成功です。Mac + Homebrewの場合は`brew install zig`でインストールできます。
 
 ```bash
 ❯ zig version


### PR DESCRIPTION
This pull request includes a small update to the installation instructions for Zig in the `books/zig-blockchain/chapter1.md` file. The change adds a note about using Homebrew to install Zig on macOS.

* [`books/zig-blockchain/chapter1.md`](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198L28-R28): Updated the installation instructions to include the Homebrew command for installing Zig on macOS.