### PR TITLE
bugfix

### DIFF
--- a/books/zig-blockchain/chapter1.md
+++ b/books/zig-blockchain/chapter1.md
@@ -182,7 +182,7 @@ fn calculateHash(block: *const Block) [32]u8 {
 
 コード全体は次のようになります。
 
-``````arc/main.zig
+```arc/main.zig
 const std = @import("std");
 const crypto = std.crypto.hash;
 const Sha256 = crypto.sha2.Sha256;
@@ -232,7 +232,6 @@ pub fn main() !void {
     try stdout.print("\n", .{});
 }
 ```
-
 
 ここまでで、ブロックの基本構造とハッシュ計算方法が定義できました。次に、このブロックに取引（トランザクション）の情報を組み込んでいきましょう。
 


### PR DESCRIPTION
This pull request includes minor formatting changes to `books/zig-blockchain/chapter1.md` to correct the code block syntax and improve readability.

Formatting improvements:

* [`books/zig-blockchain/chapter1.md`](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198L185-R185): Corrected the code block syntax from ``````arc/main.zig` to ```arc/main.zig`.
* [`books/zig-blockchain/chapter1.md`](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198L236): Removed an unnecessary blank line for better readability.