### PR TITLE
change color

### DIFF
--- a/books/zig-blockchain/chapter1.md
+++ b/books/zig-blockchain/chapter1.md
@@ -52,7 +52,7 @@ info: see `zig build --help` for a menu of options
 
 環境確認のため、簡単なZigプログラムを作成してみます。src/main.zigを更新して、以下のコードを書いてください。
 
-```bash
+```zig
 const std = @import("std");
 
 pub fn main() !void {
@@ -95,7 +95,7 @@ zig run src/main.zig
 
 Zigでは以下のように`struct`を使ってブロックの型を定義できます。
 
-```bash
+```zig
 const std = @import("std");
 
 // ブロックを表す構造体
@@ -110,7 +110,7 @@ const Block = struct {
 
 上記ではハッシュ値を256ビット（32バイト）長の配列 `[32]u8` で表しています。これはSHA-256などの暗号学的ハッシュ関数で得られるハッシュのサイズに合わせたものです。`data`フィールドは`[]const u8`（バイト列）としており、簡単のためブロックに格納するデータを文字列やバイナリ列で扱えるようにしています。
 
-```bash
+```zig
 const std = @import("std");
 
 /// ブロックチェーンの1ブロックを表す構造体
@@ -162,7 +162,7 @@ Data       : Hello, Zig Blockchain!
 
 ZigでSHA-256を使うには、`std.crypto.hash.sha2`名前空間の`Sha256`型を利用します。以下にブロックのハッシュ値を計算する関数の例を示します。
 
-```bash
+```zig
 const std = @import("std");
 const crypto = std.crypto.hash;  // ハッシュ用の名前空間
 const Sha256 = crypto.sha2.Sha256;


### PR DESCRIPTION
This pull request includes changes to the `books/zig-blockchain/chapter1.md` file to correct the code block language specification from `bash` to `zig`. This change ensures proper syntax highlighting for Zig code examples in the documentation.

Changes to code block language specification:

* Updated the language specification from `bash` to `zig` in multiple code blocks to ensure proper syntax highlighting. [[1]](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198L55-R55) [[2]](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198L98-R98) [[3]](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198L113-R113) [[4]](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198L165-R165)