### PR TITLE
add endian

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,68 @@
 # zenn-article
 
-Zenn article repository
+技術記事とブックコンテンツを管理するZennのリポジトリです。
 
-## Create new article
+## 開発環境のセットアップ
+
+必要な依存関係をインストールします。
+
+```bash
+npm install
+pip install -r requirements.txt
+pre-commit install
+```
+
+## 記事の作成
+
+新しい記事を作成するには以下のコマンドを使用します。
 
 ```bash
 npx zenn new:article
 ```
 
-With title and slug
+タイトルとスラッグを指定して作成する場合は以下のコマンドを使用します。
 
 ```bash
 npx zenn new:article --slug <slug> --title <title> --type idea --emoji ✨
 ```
 
-or
+または、Makefileを使用します。
 
 ```bash
 make new_article slug=<slug> title="<title>"
 ```
+
+## ブックの作成
+
+新しいブックを作成するには以下のコマンドを使用します。
+
+```bash
+npx zenn new:book
+```
+
+## プレビュー
+
+コンテンツをローカルでプレビューするには以下のコマンドを実行します。
+
+```bash
+npx zenn preview
+```
+
+## リンター
+
+このプロジェクトでは以下のリンターを使用しています。
+
+- textlint: Markdown文書のリント
+- pre-commit: コミット前のコード品質チェック
+
+リンターを手動で実行するには以下のコマンドを使用します。
+
+```bash
+make lint
+```
+
+## 利用可能なMakeコマンド
+
+- `make lint`: リンターを実行します。
+- `make new_article`: 新しい記事を作成します。
+- `make preview`: ローカルプレビューを開始します。


### PR DESCRIPTION
This pull request includes updates to the `README.md` file and significant changes to the Zig blockchain implementation in `chapter1.md`. The updates focus on improving documentation and enhancing the blockchain's functionality.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R68): Updated the repository description and added instructions for setting up the development environment, creating articles and books, previewing content, and running linters.

Blockchain functionality enhancements:

* [`books/zig-blockchain/chapter1.md`](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198L760-R762): Improved the difficulty check in `meetsDifficulty` function by limiting the range to 32 bytes.
* [`books/zig-blockchain/chapter1.md`](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198R791-R849): Added helper functions for converting `u32` and `u64` values to little-endian byte arrays and updated the `toBytes` function to handle these conversions. [[1]](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198R791-R849) [[2]](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198R862-L851)
* [`books/zig-blockchain/chapter1.md`](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198R862-L851): Enhanced the `Block` struct with detailed comments and added new helper functions for byte conversion.
* [`books/zig-blockchain/chapter1.md`](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198R984-R1001): Updated the `calculateHash` function to include all fields of the `Block` struct in the hash calculation and improved the `mineBlock` function to increment the nonce until the difficulty condition is met.
* [`books/zig-blockchain/chapter1.md`](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198L894-R1034): Improved the `main` function to initialize the genesis block, calculate its hash, and print the results with detailed output. [[1]](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198L894-R1034) [[2]](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198L923-R1053) [[3]](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198L970-L1067)