### PR TITLE
update zig 0.14.0

### DIFF
--- a/books/zig-blockchain/setup.md
+++ b/books/zig-blockchain/setup.md
@@ -25,7 +25,7 @@ Zig公式サイトから各プラットフォーム向けのバイナリをダ�
 
 ```bash
 ❯ zig version
-0.13.0
+0.14.0
 ```
 
 ### ビルドツールとエディタの準備
@@ -60,7 +60,7 @@ pub fn main() !void {
 次に、準備したターミナルで次のコマンドを実行してみましょう。
 
 ```bash
-zig run src/main.zig
+zig build run
 ```
 
 `zig run`コマンドはソースをビルドして即座に実行してくれます。正しく環境構築できていれば、コンソールに **Hello, world** と表示されるはずです。これでZigの開発環境は準備完了です。
@@ -96,7 +96,7 @@ COPY --chown=appuser:appgroup . .
 # 一般ユーザーに切り替え
 USER appuser
 
-CMD ["zig", "run", "src/main.zig"]
+CMD ["zig", "build", "run"]
 ```
 
 上記のDockerfileでは、Alpineイメージを基に`apk add zig`コマンドでZigをインストールしています（Alpineのedgeリポジトリから取得）。`WORKDIR /app`は作業ディレクトリを設定しており、後でソースコードをここに配置してビルドできるようにしています。
@@ -190,7 +190,7 @@ jobs:
     - name: Setup Zig
       uses: goto-bus-stop/setup-zig@v2
       with:
-        version: 0.13.0
+        version: 0.14.0
 
     - name: Run tests
       run: zig build test


### PR DESCRIPTION
This pull request includes updates to the `books/zig-blockchain/setup.md` file to reflect changes in the Zig version and build commands. The most important changes include updating the Zig version from 0.13.0 to 0.14.0 and modifying the commands to use `zig build run` instead of `zig run`.

Updates to Zig version:

* Changed the Zig version from 0.13.0 to 0.14.0 in the version check command.
* Updated the Zig version from 0.13.0 to 0.14.0 in the setup instructions for GitHub Actions.

Modifications to build commands:

* Replaced the `zig run src/main.zig` command with `zig build run` in the terminal instructions.
* Updated the Dockerfile to use `zig build run` instead of `zig run src/main.zig`.