### PR TITLE
add docker compose steps for zig 0.14

### DIFF
--- a/books/zig-blockchain/chapter1.md
+++ b/books/zig-blockchain/chapter1.md
@@ -92,10 +92,33 @@ pub fn main() !void {
 実行してみると、ブロックの情報が表示されるはずです。
 
 ```bash
-❯ zig run src/main.zig
+❯ zig build run
 Block index: 1
 Timestamp  : 1672531200
 Data       : Hello, Zig Blockchain!
+```
+
+もしくはdocker composeで実行できます。
+
+```bash
+❯ docker compose up
+[+] Running 3/3
+ ✔ Container node1  Recreate...                   0.1s
+ ✔ Container node2  Recreate...                   0.1s
+ ✔ Container node3  Recreate...                   0.1s
+Attaching to node1, node2, node3
+node3  | Block index: 1
+node3  | Timestamp  : 1672531200
+node3  | Data       : Hello, Zig Blockchain!
+node1  | Block index: 1
+node1  | Timestamp  : 1672531200
+node1  | Data       : Hello, Zig Blockchain!
+node2  | Block index: 1
+node2  | Timestamp  : 1672531200
+node2  | Data       : Hello, Zig Blockchain!
+node3 exited with code 0
+node1 exited with code 0
+node2 exited with code 0
 ```
 
 ### ステップ2: ハッシュ計算を追加し、`hash`フィールドを埋める


### PR DESCRIPTION
This pull request includes updates to the Zig Blockchain book to improve the Docker setup and execution instructions. The most important changes include updating the Dockerfile to download Zig from the official site, adding Docker Compose instructions, and specifying the platform for Docker services.

### Docker setup improvements:

* [`books/zig-blockchain/setup.md`](diffhunk://#diff-a798d42e5cd20b6625a560e0e4238f67fa2fea529771dea9fb56f64cd3de5d22L80-R114): Updated the Dockerfile to download Zig from the official site instead of using the `apk add zig` command. This includes adding necessary tools and setting environment variables for Zig version and distribution.
* [`books/zig-blockchain/setup.md`](diffhunk://#diff-a798d42e5cd20b6625a560e0e4238f67fa2fea529771dea9fb56f64cd3de5d22R129-R145): Added `platform: linux/amd64` to each service in the Docker Compose file to ensure compatibility with the specified architecture.

### Execution instructions:

* [`books/zig-blockchain/chapter1.md`](diffhunk://#diff-0ac6c983c0d0f22c5c471e5ae6841db9ae4c5fa1ead1b67ddecbeee4f73ad198L95-R123): Updated the execution command from `zig run src/main.zig` to `zig build run` and added an alternative method using Docker Compose.

### Docker Compose details:

* [`books/zig-blockchain/setup.md`](diffhunk://#diff-a798d42e5cd20b6625a560e0e4238f67fa2fea529771dea9fb56f64cd3de5d22L139-R154): Updated the Compose file explanation to reflect the changes in the Dockerfile and the addition of the platform specification.