### PR TITLE
fix typo

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,28 @@
+{
+  "mcp": {
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "github_token",
+        "description": "GitHub Personal Access Token",
+        "password": true
+      }
+    ],
+    "servers": {
+      "github": {
+        "command": "docker",
+        "args": [
+          "run",
+          "-i",
+          "--rm",
+          "-e",
+          "GITHUB_PERSONAL_ACCESS_TOKEN",
+          "ghcr.io/github/github-mcp-server"
+        ],
+        "env": {
+          "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github_token}"
+        }
+      }
+    }
+  }
+}

--- a/books/zig-blockchain/chapter7.md
+++ b/books/zig-blockchain/chapter7.md
@@ -1227,13 +1227,12 @@ zig build run -- --connect 127.0.0.1:8080
 クライアントのコンソールから```BLOCK:{"index":2,"nonce":777}```のメッセージを送ってみます。
 
 ```bash
-❯ zig build run -- --connect 127.0.0.1:8080
+❯ zig build run -- --connect 127.0.0.1:8081
 info: Connecting to 127.0.0.1:8081...
 Enter message for new block: hi
 ```
 
 ```bash
-❯ zig build run -- --listen 8080
 ❯ zig build run -- --listen 8081
 info: Listening on 0.0.0.0:8081
 info: Accepted: 127.0.0.1:60237


### PR DESCRIPTION
This pull request includes changes to the `.vscode/mcp.json` configuration file and an update to the `books/zig-blockchain/chapter7.md` documentation. The most important changes are as follows:

Configuration updates:

* [`.vscode/mcp.json`](diffhunk://#diff-756c99ad6a15758981c15d6ba32a2d83391908e8e021f0399e9d34339dc4eadaR1-R28): Added a new configuration file to support GitHub Personal Access Token input and Docker command execution for the GitHub MCP server.

Documentation updates:

* [`books/zig-blockchain/chapter7.md`](diffhunk://#diff-81eca69c0bb6e48931e590b2c1b600b8e973512bce1bc10645b7f88e1b108f1fL1230-L1236): Updated the connection port from `8080` to `8081` in the example commands to reflect the correct port usage.