### PR TITLE
split peer struct

### DIFF
--- a/books/zig-blockchain/chapter7.md
+++ b/books/zig-blockchain/chapter7.md
@@ -51,8 +51,9 @@ free: true
 ## ネットワーク接続相手に関する構造体を定義
 
 まず、ネットワーク接続相手(ピア)に関する情報を扱う構造体を用意します。IPアドレスやTCPストリームを保持し、送受信で使い回します。
+types.zigに次のような構造体を追加します。
 
-```zig
+```types.zig
 const Peer = struct {
     address: std.net.Address,
     stream: std.net.Stream,


### PR DESCRIPTION
This pull request includes a small change to the `books/zig-blockchain/chapter7.md` file. The change clarifies the file name where a new structure should be added, ensuring the correct file `types.zig` is referenced instead of a generic code block.