### PR TITLE
Claude用Spec-Driven Developmentコマンド群の追加

### DIFF
--- a/.claude/commands/spec-design.md
+++ b/.claude/commands/spec-design.md
@@ -1,0 +1,229 @@
+---
+description: Create technical design for a specification
+allowed-tools: Bash, Read, Write, Edit, MultiEdit, Update, WebSearch, WebFetch
+---
+
+# Technical Design
+
+Create comprehensive technical design for feature: **$ARGUMENTS**
+
+## Approval Gate: Requirements Check
+
+**CRITICAL**: Design can only be generated after requirements are approved.
+
+### Approval Status Check
+- Spec metadata: @.kiro/specs/$ARGUMENTS/spec.json
+
+**STOP HERE** if spec.json shows:
+```json
+"approvals": {
+  "requirements": {
+    "approved": false
+  }
+}
+```
+
+**Required Actions for Requirements Approval**:
+1. **Review requirements.md** - Read through the generated requirements thoroughly
+2. **Edit if needed** - Make any necessary changes directly in the requirements.md file
+3. **Manual approval required** - Update spec.json manually to set `"requirements": {"approved": true}`
+4. **Reasoning**: Human review ensures requirements accuracy before design phase
+
+**Example approval in spec.json**:
+```json
+{
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true  // ← Set this to true after human review
+    }
+  },
+  "phase": "requirements-approved"
+}
+```
+
+**Only proceed to design generation after requirements are explicitly approved by human review.**
+
+## Context Analysis
+
+### Steering Context
+- Current architecture: @.kiro/steering/structure.md
+- Technology stack: @.kiro/steering/tech.md
+- Product constraints: @.kiro/steering/product.md
+
+### Requirements Context (APPROVED)
+- Feature requirements: @.kiro/specs/$ARGUMENTS/requirements.md
+- Current design: @.kiro/specs/$ARGUMENTS/design.md
+- Spec metadata: @.kiro/specs/$ARGUMENTS/spec.json
+
+## Task: Create Technical Design
+
+**Prerequisites Verified**: Requirements are approved and ready for design phase.
+
+Generate comprehensive design document in the language specified in spec.json:
+
+### 1. Design Document Structure
+Create design.md in the language specified in spec.json (check `@.kiro/specs/$ARGUMENTS/spec.json` for "language" field):
+
+```markdown
+# Technical Design
+
+## Overview
+[Technical overview of the implementation approach]
+
+## Architecture
+[Architecture diagram using mermaid]
+
+```mermaid
+graph TB
+    A[Frontend Layer] --> B[API Gateway]
+    B --> C[Business Logic]
+    C --> D[Data Layer]
+    D --> E[Database]
+```
+
+## Technology Stack
+- **Frontend**: [React/Vue/Next.js] + [TypeScript]
+- **Backend**: [FastAPI/Express/Django] + [Language]
+- **Database**: [PostgreSQL/MySQL/MongoDB]
+- **Authentication**: [JWT/OAuth/Auth0]
+- **Testing**: [Jest/pytest] + [Testing Library/Playwright]
+- **Deployment**: [Docker/Vercel/AWS]
+
+## Components and Interfaces
+[Detailed component design with clear interfaces]
+
+### API Endpoints
+```
+GET /api/[resource]
+POST /api/[resource]
+PUT /api/[resource]/:id
+DELETE /api/[resource]/:id
+```
+
+### Data Flow
+[Description of how data flows through the system]
+
+## Data Models
+[Data structures and database schemas]
+
+```typescript
+interface [ModelName] {
+  id: string;
+  // Add relevant fields
+}
+```
+
+## Error Handling
+[Comprehensive error handling strategy]
+
+## Security Considerations
+[Authentication, authorization, data validation]
+
+## Performance & Scalability
+[Caching, optimization, scaling strategy]
+
+## Testing Strategy
+[Unit, integration, and E2E testing approach]
+```
+
+### 2. Design Quality Guidelines
+- **Architecture Alignment**: Follow existing architectural patterns
+- **Technology Consistency**: Use established technology stack
+- **Interface Design**: Define clear component interfaces
+- **Data Modeling**: Design appropriate data structures
+- **Error Handling**: Plan comprehensive error scenarios
+- **Testing Strategy**: Include unit, integration, and E2E testing
+
+### 3. Integration Considerations
+Based on steering and requirements:
+- How components integrate with existing architecture
+- Database schema changes required
+- API endpoint design
+- Performance considerations
+- Security requirements
+
+### 4. Mermaid Diagrams
+Include relevant diagrams:
+- System architecture
+- Component interactions
+- Data flow diagrams
+- Sequence diagrams for key workflows
+
+### 5. Update Metadata
+Update spec.json with:
+```json
+{
+  "phase": "design-generated",
+  "progress": {
+    "requirements": 100,
+    "design": 100,
+    "tasks": 0
+  },
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": false
+    }
+  },
+  "updated_at": "current_timestamp"
+}
+```
+
+### 6. Document Generation Only
+Generate the design document content ONLY. Do not include any review or approval instructions in the actual document file.
+
+---
+
+## REVIEW AND APPROVAL PROCESS (Not included in document)
+
+The following is for Claude Code conversation only - NOT for the generated document:
+
+### Human Review Required
+After generating design.md, inform the user:
+
+**NEXT STEP**: Human review required before proceeding to tasks phase.
+
+### Review Checklist:
+- [ ] Technical design is comprehensive and clear
+- [ ] Architecture aligns with existing system
+- [ ] Technology choices are appropriate
+- [ ] Components and interfaces are well-defined
+- [ ] Security and performance considerations are addressed
+
+### To Approve:
+After reviewing, update `.kiro/specs/$ARGUMENTS/spec.json`:
+```json
+{
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "phase": "design-approved"
+}
+```
+
+**Only after approval can you proceed to `/spec-tasks $ARGUMENTS`**
+
+## Instructions
+
+1. **Check spec.json for language** - Use the language specified in the metadata
+2. **Analyze requirements thoroughly** to understand scope
+3. **Follow existing architecture patterns** from steering
+4. **Create detailed component design** with clear interfaces
+5. **Include comprehensive diagrams** using mermaid
+6. **Plan error handling and testing** strategies
+7. **Update tracking metadata** upon completion
+
+Generate design that provides clear blueprint for implementation phase.
+ultrathink

--- a/.claude/commands/spec-init.md
+++ b/.claude/commands/spec-init.md
@@ -1,0 +1,156 @@
+---
+description: Initialize a new specification with detailed project description and requirements
+allowed-tools: Bash, Read, Write, Glob
+---
+
+# Spec Initialization
+
+Initialize a new specification based on the provided project description:
+
+**Project Description**: $ARGUMENTS
+
+## Steering Context Validation
+
+### Check Steering Documents
+- Structure context: @.kiro/steering/structure.md
+- Technical constraints: @.kiro/steering/tech.md  
+- Product context: @.kiro/steering/product.md
+
+### Verify Steering Exists
+- Steering files: !`ls -la .kiro/steering/`
+
+**FLEXIBILITY**: For new features or empty projects, steering documents are recommended but not required. If steering documents are missing or empty, you may proceed directly to spec generation phase.
+
+## Task: Initialize Specification Structure
+
+**SCOPE**: This command initializes the directory structure and metadata based on the detailed project description provided.
+
+### 1. Analyze Project Description
+From the provided description ($ARGUMENTS), extract:
+- Project purpose and goals
+- Key features and functionality
+- Target users or use cases
+- Technical requirements or constraints
+- Any specific implementation details mentioned
+
+### 2. Generate Feature Name
+Based on the analysis, create a concise, descriptive feature name that captures the essence of the project.
+
+### 3. Create Spec Directory
+Create `.kiro/specs/{generated-feature-name}/` directory with template files:
+- `requirements.md` - Empty template for user stories
+- `design.md` - Empty template for technical design  
+- `tasks.md` - Empty template for implementation tasks
+- `spec.json` - Metadata and approval tracking
+
+### 4. Initialize spec.json Metadata
+Create initial metadata with approval tracking and project description:
+```json
+{
+  "feature_name": "{generated-feature-name}",
+  "project_description": "$ARGUMENTS",
+  "created_at": "current_timestamp",
+  "updated_at": "current_timestamp",
+  "language": "japanese",
+  "phase": "initialized",
+  "approvals": {
+    "requirements": {
+      "generated": false,
+      "approved": false
+    },
+    "design": {
+      "generated": false,
+      "approved": false
+    },
+    "tasks": {
+      "generated": false,
+      "approved": false
+    }
+  },
+  "progress": {
+    "requirements": 0,
+    "design": 0,
+    "tasks": 0
+  },
+  "ready_for_implementation": false
+}
+```
+
+### 5. Create Template Files with Project Context
+
+#### requirements.md (Template with Context)
+```markdown
+# Requirements Document
+
+## Project Overview
+{Brief summary of the project based on the provided description}
+
+## Project Description (User Input)
+$ARGUMENTS
+
+## Requirements
+<!-- Detailed user stories will be generated in /spec-requirements phase -->
+
+---
+**STATUS**: Ready for requirements generation
+**NEXT STEP**: Run `/spec-requirements {feature-name}` to generate detailed requirements
+```
+
+#### design.md (Empty Template)
+```markdown
+# Design Document
+
+## Overview
+<!-- Technical design will be generated after requirements approval -->
+
+---
+**STATUS**: Waiting for requirements approval
+**NEXT STEP**: Complete and approve requirements first
+```
+
+#### tasks.md (Empty Template)
+```markdown
+# Implementation Plan
+
+<!-- Implementation tasks will be generated after design approval -->
+
+---
+**STATUS**: Waiting for design approval  
+**NEXT STEP**: Complete and approve design first
+```
+
+### 6. Update CLAUDE.md Reference
+Add the new spec to the active specifications list with the generated feature name and a brief description.
+
+## Next Steps After Initialization
+
+Follow the proper spec-driven development workflow:
+
+**Standard workflow:**
+1. **Generate requirements**: `/spec-requirements {feature-name}`
+2. **Review and approve requirements**: Update spec.json
+3. **Generate design**: `/spec-design {feature-name}` (after requirements approval)
+4. **Review and approve design**: Update spec.json
+5. **Generate tasks**: `/spec-tasks {feature-name}` (after design approval)
+6. **Review and approve tasks**: Update spec.json
+7. **Start implementation**: After all approvals are complete
+
+## Instructions
+
+1. **Parse project description** - Extract key information from the detailed description
+2. **Generate appropriate feature name** - Create a concise, descriptive name
+3. **Check steering documents** - recommended but not required for new features
+4. **Create directory structure** - Include project context in templates
+5. **Set up approval tracking** in metadata with project description
+6. **Provide clear next steps** for the user with the generated feature name
+7. **Enable flexible workflow** - allow direct progression to requirements when appropriate
+
+## Output Format
+
+After initialization, provide:
+1. Generated feature name and rationale
+2. Brief project summary
+3. Created file paths
+4. Clear next steps with the exact command to run
+
+This ensures the proper spec-driven development workflow with mandatory review phases between each step.

--- a/.claude/commands/spec-requirements.md
+++ b/.claude/commands/spec-requirements.md
@@ -1,0 +1,137 @@
+---
+description: Generate comprehensive requirements for a specification
+allowed-tools: Bash, Read, Write, Edit, MultiEdit, Update, WebSearch, WebFetch
+---
+
+# Requirements Generation
+
+Generate comprehensive requirements for feature: **$ARGUMENTS**
+
+## Context Validation
+
+### Steering Context
+- Architecture context: @.kiro/steering/structure.md
+- Technical constraints: @.kiro/steering/tech.md
+- Product context: @.kiro/steering/product.md
+
+### Existing Spec Context
+- Current spec directory: !`ls -la .kiro/specs/$ARGUMENTS/`
+- Current requirements: @.kiro/specs/$ARGUMENTS/requirements.md
+- Spec metadata: @.kiro/specs/$ARGUMENTS/spec.json
+
+## Task: Generate Detailed Requirements
+
+Create comprehensive requirements document in the language specified in spec.json:
+
+### 1. Requirements Structure
+Generate requirements.md in the language specified in spec.json (check `@.kiro/specs/$ARGUMENTS/spec.json` for "language" field):
+
+```markdown
+# Requirements Specification
+
+## Overview
+[Clear overview of the feature and its purpose]
+
+## Requirements
+
+### Requirement 1
+**User Story:** As a [user type], I want to [do something], so that I can [achieve some goal]
+
+#### Acceptance Criteria
+1. WHEN [specific condition] THEN [specific expected outcome]
+2. WHEN [specific condition] THEN [specific expected outcome]
+3. IF [exception condition] THEN [expected error handling]
+
+### Requirement 2
+**User Story:** As a [user type], I want to [do something], so that I can [achieve some goal]
+
+#### Acceptance Criteria
+1. WHEN [specific condition] THEN [specific expected outcome]
+2. WHEN [specific condition] THEN [specific expected outcome]
+3. IF [exception condition] THEN [expected error handling]
+
+### Requirement 3
+[Additional requirements following same pattern]
+```
+
+### 2. Requirements Quality Guidelines
+- **User-Centric**: Write from user perspective
+- **Testable**: Each acceptance criterion should be verifiable
+- **Specific**: Use concrete conditions and outcomes
+- **Complete**: Cover all major user scenarios
+- **Contextual**: Consider existing system integration
+
+### 3. Integration Considerations
+Based on steering context, consider:
+- How this feature fits with existing architecture
+- Technical constraints that affect requirements
+- Existing user workflows that need integration
+- Performance and scalability requirements
+
+### 4. Update Metadata
+Update spec.json with:
+```json
+{
+  "phase": "requirements-generated",
+  "progress": {
+    "requirements": 100,
+    "design": 0,
+    "tasks": 0
+  },
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": false
+    }
+  },
+  "updated_at": "current_timestamp"
+}
+```
+
+### 5. Document Generation Only
+Generate the requirements document content ONLY. Do not include any review or approval instructions in the actual document file.
+
+---
+
+## REVIEW AND APPROVAL PROCESS (Not included in document)
+
+The following is for Claude Code conversation only - NOT for the generated document:
+
+### Human Review Required
+After generating requirements.md, inform the user:
+
+**NEXT STEP**: Human review required before proceeding to design phase.
+
+### Review Checklist:
+- [ ] Requirements are clear and complete
+- [ ] User stories cover all necessary functionality
+- [ ] Acceptance criteria are testable
+- [ ] Requirements align with project goals
+
+### To Approve:
+After reviewing, update `.kiro/specs/$ARGUMENTS/spec.json`:
+```json
+{
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "phase": "requirements-approved"
+}
+```
+
+**Only after approval can you proceed to `/spec-design $ARGUMENTS`**
+
+## Instructions
+
+1. **Check spec.json for language** - Use the language specified in the metadata
+2. **Analyze existing product context** to understand user needs
+3. **Create user-focused requirements** with clear acceptance criteria
+4. **Consider technical constraints** from steering documents
+5. **Ensure requirements are testable** and specific
+6. **Update tracking metadata** upon completion
+
+Generate requirements that provide clear foundation for design phase.
+ultrathink

--- a/.claude/commands/spec-status.md
+++ b/.claude/commands/spec-status.md
@@ -1,0 +1,96 @@
+---
+description: Show specification status and progress
+allowed-tools: Bash, Read, Glob, Write, Edit, MultiEdit, Update
+---
+
+# Specification Status
+
+Show current status and progress for feature: **$ARGUMENTS**
+
+## Spec Context
+
+### Spec Files
+- Spec directory: !`ls -la .kiro/specs/$ARGUMENTS/`
+- Spec metadata: @.kiro/specs/$ARGUMENTS/spec.json
+- Requirements: @.kiro/specs/$ARGUMENTS/requirements.md
+- Design: @.kiro/specs/$ARGUMENTS/design.md
+- Tasks: @.kiro/specs/$ARGUMENTS/tasks.md
+
+### All Specs Overview
+- Available specs: !`ls -la .kiro/specs/`
+- Active specs: !`find .kiro/specs/ -name "spec.json" -exec grep -l "implementation_ready.*true" {} \;`
+
+## Task: Generate Status Report
+
+Create comprehensive status report for the specification in the language specified in spec.json (check `@.kiro/specs/$ARGUMENTS/spec.json` for "language" field):
+
+### 1. Specification Overview
+Display:
+- Feature name and description
+- Creation date and last update
+- Current phase (requirements/design/tasks/implementation)
+- Overall completion percentage
+
+### 2. Phase Status
+For each phase, show:
+- ✅ **Requirements Phase**: [completion %]
+  - Requirements count: [number]
+  - Acceptance criteria defined: [yes/no]
+  - Requirements coverage: [complete/partial/missing]
+
+- ✅ **Design Phase**: [completion %]
+  - Architecture documented: [yes/no]
+  - Components defined: [yes/no]
+  - Diagrams created: [yes/no]
+  - Integration planned: [yes/no]
+
+- ✅ **Tasks Phase**: [completion %]
+  - Total tasks: [number]
+  - Completed tasks: [number]
+  - Remaining tasks: [number]
+  - Blocked tasks: [number]
+
+### 3. Implementation Progress
+If in implementation phase:
+- Task completion breakdown
+- Current blockers or issues
+- Estimated time to completion
+- Next actions needed
+
+#### Task Completion Tracking
+- Parse tasks.md checkbox status: `- [x]` (completed) vs `- [ ]` (pending)
+- Count completed vs total tasks
+- Show completion percentage
+- Identify next uncompleted task
+
+### 4. Quality Metrics
+Show:
+- Requirements coverage: [percentage]
+- Design completeness: [percentage]
+- Task granularity: [appropriate/too large/too small]
+- Dependencies resolved: [yes/no]
+
+### 5. Recommendations
+Based on status, provide:
+- Next steps to take
+- Potential issues to address
+- Suggested improvements
+- Missing elements to complete
+
+### 6. Steering Alignment
+Check alignment with steering documents:
+- Architecture consistency: [aligned/misaligned]
+- Technology stack compliance: [compliant/non-compliant]
+- Product requirements alignment: [aligned/misaligned]
+
+## Instructions
+
+1. **Check spec.json for language** - Use the language specified in the metadata
+2. **Parse all spec files** to understand current state
+3. **Calculate completion percentages** for each phase
+4. **Identify next actions** based on current progress
+5. **Highlight any blockers** or issues
+6. **Provide clear recommendations** for moving forward
+7. **Check steering alignment** to ensure consistency
+
+Generate status report that provides clear visibility into spec progress and next steps.

--- a/.claude/commands/spec-tasks.md
+++ b/.claude/commands/spec-tasks.md
@@ -1,0 +1,277 @@
+---
+description: Generate implementation tasks for a specification
+allowed-tools: Bash, Read, Write, Edit, Update, MultiEdit
+---
+
+# Implementation Tasks
+
+Generate detailed implementation tasks for feature: **$ARGUMENTS**
+
+## Approval Gate: Requirements & Design Check
+
+**CRITICAL**: Tasks can only be generated after both requirements and design are approved.
+
+### Approval Status Check
+- Spec metadata: @.kiro/specs/$ARGUMENTS/spec.json
+
+**STOP HERE** if spec.json shows:
+```json
+"approvals": {
+  "requirements": {
+    "approved": false  // Must be true
+  },
+  "design": {
+    "approved": false  // Must be true
+  }
+}
+```
+
+**Required Actions for Full Approval**:
+
+### If Requirements Not Approved:
+1. **Review requirements.md** - Read through the generated requirements thoroughly
+2. **Edit if needed** - Make any necessary changes directly in the requirements.md file
+3. **Manual approval required** - Update spec.json to set `"requirements": {"approved": true}`
+
+### If Design Not Approved:
+1. **Review design.md** - Read through the generated design thoroughly
+2. **Edit if needed** - Make any necessary changes directly in the design.md file
+3. **Manual approval required** - Update spec.json to set `"design": {"approved": true}`
+4. **Reasoning**: Human review ensures technical design accuracy before task breakdown
+
+**Example full approval in spec.json**:
+```json
+{
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true  // ← Human reviewed and approved
+    },
+    "design": {
+      "generated": true,
+      "approved": true  // ← Human reviewed and approved
+    }
+  },
+  "phase": "design-approved"
+}
+```
+
+**Only proceed to task generation after both requirements and design are explicitly approved by human review.**
+
+## Context Analysis
+
+### Complete Spec Context (APPROVED)
+- Requirements: @.kiro/specs/$ARGUMENTS/requirements.md
+- Design: @.kiro/specs/$ARGUMENTS/design.md
+- Current tasks: @.kiro/specs/$ARGUMENTS/tasks.md
+- Spec metadata: @.kiro/specs/$ARGUMENTS/spec.json
+
+### Steering Context
+- Architecture patterns: @.kiro/steering/structure.md
+- Development practices: @.kiro/steering/tech.md
+- Product constraints: @.kiro/steering/product.md
+
+## Task: Generate Implementation Plan
+
+**Prerequisites Verified**: Both requirements and design are approved and ready for task breakdown.
+
+Create comprehensive implementation plan in the language specified in spec.json:
+
+### 1. Tasks Document Structure
+Create tasks.md in the language specified in spec.json (check `@.kiro/specs/$ARGUMENTS/spec.json` for "language" field):
+
+```markdown
+# Implementation Plan
+
+- [ ] 1. Project Setup and Core Structure
+  - Create frontend (React/Vue/Next.js) and backend (FastAPI/Express) directory structure
+  - Define TypeScript types and core data model interfaces
+  - Set up development environment files (package.json, requirements.txt, docker-compose.yml)
+  - _Requirements: 1.1, 1.2_
+
+- [ ] 2. Database and Model Layer Implementation
+- [ ] 2.1 Database Schema Design and Implementation
+  - Define schemas using [ORM/Database] (Prisma/SQLAlchemy/Mongoose)
+  - Create and run migration files
+  - Implement database connection utilities
+  - _Requirements: 2.1, 2.2_
+
+- [ ] 2.2 Data Validation and Business Logic
+  - Implement model validation functions
+  - Implement and test business rules
+  - Standardize error handling across models
+  - _Requirements: 2.3_
+
+- [ ] 3. API and Backend Services Implementation
+- [ ] 3.1 Authentication and Authorization System
+  - Implement JWT/session authentication with [Auth Library]
+  - Create user registration and login endpoints
+  - Implement access control middleware and route protection
+  - _Requirements: 3.1, 3.2_
+
+- [ ] 3.2 Core API Endpoints Implementation
+  - Implement CRUD operations for main entities
+  - Add input validation and sanitization
+  - Create API documentation with OpenAPI/Swagger
+  - _Requirements: 3.3, 3.4_
+
+- [ ] 4. Frontend Component Implementation
+- [ ] 4.1 Basic UI Component Creation
+  - Select and configure component library ([Chakra UI/Material-UI/Tailwind])
+  - Implement common components (Button, Input, Modal, Table)
+  - Set up responsive design system and theme
+  - _Requirements: 4.1, 4.2_
+
+- [ ] 4.2 Feature-Specific Components
+  - Implement main feature components based on requirements
+  - Add form handling with validation ([Formik/React Hook Form])
+  - Implement state management ([Redux/Zustand/Context])
+  - _Requirements: 4.3, 4.4_
+
+- [ ] 5. Integration and Testing
+- [ ] 5.1 Test Suite Implementation
+  - Create unit tests for backend services (Jest/pytest)
+  - Implement API integration tests
+  - Set up frontend component tests ([Testing Library])
+  - _Requirements: All requirements test coverage_
+
+- [ ] 5.2 End-to-End Testing and Deployment
+  - Implement E2E tests ([Playwright/Cypress])
+  - Set up CI/CD pipeline configuration
+  - Configure production deployment and monitoring
+  - _Requirements: 5.1, 5.2_
+```
+
+**Key Format Rules**:
+- Hierarchical numbering: Major phases (1, 2, 3) and sub-tasks (1.1, 1.2)
+- Each task contains 2-4 concrete, actionable items
+- Specify technologies in brackets: [React], [FastAPI], [Prisma]
+- End with requirement mapping: _Requirements: X.X, Y.Y_
+- Tasks should be completable in 2-4 hours each
+- Include testing tasks for each major component
+
+### 2. Task Quality Guidelines
+- **Hierarchical Structure**: Group related tasks into phases
+- **Discrete Tasks**: Each task should be completable in 2-4 hours
+- **Clear Acceptance Criteria**: Define what "done" means
+- **Requirements Mapping**: Link tasks to specific requirements
+- **Dependency Management**: Order tasks by dependencies
+- **Testable Outcomes**: Each task should have verifiable results
+
+### 3. Task Categories
+Include tasks for:
+- **Data Models**: Database schema and model creation
+- **API Endpoints**: Backend service implementation
+- **UI Components**: Frontend component development
+- **Integration**: Service integration and workflow
+- **Testing**: Unit, integration, and E2E tests
+- **Documentation**: Code documentation and user guides
+
+### 4. Requirements Mapping
+For each task, reference the specific requirements from requirements.md:
+- Map to user stories (要件1, 要件2, etc.)
+- Include acceptance criteria references
+- Ensure full requirements coverage
+
+### 5. Progress Tracking
+Include progress tracking section:
+```markdown
+## 進捗状況
+- Created: [timestamp]
+- Status: Ready for implementation
+- Total tasks: [count]
+- Completed: 0
+- Remaining: [count]
+```
+
+### 6. Document Generation Only
+Generate the tasks document content ONLY. Do not include any review or approval instructions in the actual document file.
+
+### 7. Update Metadata
+
+Update spec.json with:
+```json
+{
+  "phase": "tasks-generated",
+  "progress": {
+    "requirements": 100,
+    "design": 100, 
+    "tasks": 100
+  },
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": false
+    }
+  },
+  "updated_at": "current_timestamp"
+}
+```
+
+### 8. Metadata Update
+Update the tracking metadata to reflect task generation completion.
+
+---
+
+## REVIEW AND APPROVAL PROCESS (Not included in document)
+
+The following is for Claude Code conversation only - NOT for the generated document:
+
+### Human Review Required
+After generating tasks.md, inform the user:
+
+**NEXT STEP**: Human review required before starting implementation.
+
+### Review Checklist:
+- [ ] Tasks are properly sized (2-4 hours each)
+- [ ] All requirements are covered by tasks
+- [ ] Task dependencies are correct
+- [ ] Technology choices match the design
+- [ ] Testing tasks are included
+
+### To Approve:
+After reviewing, update `.kiro/specs/$ARGUMENTS/spec.json`:
+```json
+{
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "phase": "ready-for-implementation",
+  "ready_for_implementation": true
+}
+```
+
+**Only after approval can you start implementation.**
+
+## Instructions
+
+1. **Check spec.json for language** - Use the language specified in the metadata
+2. **Analyze requirements and design** to understand full scope
+3. **Create hierarchical task structure** with clear phases
+4. **Define discrete, actionable tasks** with acceptance criteria
+5. **Map all tasks to requirements** to ensure coverage
+6. **Order tasks by dependencies** for logical implementation flow
+7. **Include testing and documentation** tasks
+8. **Update tracking metadata** upon completion
+
+Generate tasks that provide clear roadmap for implementation.
+ultrathink

--- a/.claude/commands/steering-custom.md
+++ b/.claude/commands/steering-custom.md
@@ -1,0 +1,138 @@
+---
+description: Create custom Kiro steering documents for specialized project contexts
+allowed-tools: Bash, Read, Write, Edit, MultiEdit, Glob, Grep, LS
+---
+
+# Kiro Custom Steering Creation
+
+Create custom steering documents in `.kiro/steering/` for specialized contexts beyond the three foundational files (product.md, tech.md, structure.md).
+
+## Current Steering Status
+
+### Existing Steering Documents
+- Core steering files: !`ls -la .kiro/steering/*.md 2>/dev/null || echo "No steering directory found"`
+- Custom steering count: !`find .kiro/steering -name "*.md" | grep -v -E "(product|tech|structure).md" | wc -l || echo "0"`
+
+### Project Analysis
+- Specialized areas: !`find . -type d -name "test*" -o -name "spec*" -o -name "api" -o -name "auth" -o -name "security" | grep -v node_modules | grep -v .git | head -10`
+- Config patterns: !`find . -name "*.config.*" -o -name "*rc.*" -o -name ".*rc" | grep -v node_modules | head -10`
+
+## Task: Create Custom Steering Document
+
+You will create a new custom steering document based on user requirements. Common use cases include:
+
+### Common Custom Steering Types
+
+1. **API Standards** (`api-standards.md`)
+   - REST/GraphQL conventions
+   - Error handling patterns
+   - Authentication/authorization approaches
+   - Rate limiting and pagination
+   - API versioning strategy
+
+2. **Testing Approach** (`testing.md`)
+   - Test file organization
+   - Naming conventions for tests
+   - Mocking strategies
+   - Coverage requirements
+   - E2E vs unit vs integration testing
+
+3. **Code Style Guidelines** (`code-style.md`)
+   - Language-specific conventions
+   - Formatting rules beyond linters
+   - Comment standards
+   - Function/variable naming patterns
+   - Code organization principles
+
+4. **Security Policies** (`security.md`)
+   - Input validation requirements
+   - Authentication patterns
+   - Secrets management
+   - OWASP compliance guidelines
+   - Security review checklist
+
+5. **Database Conventions** (`database.md`)
+   - Schema design patterns
+   - Migration strategies
+   - Query optimization guidelines
+   - Connection pooling settings
+   - Backup and recovery procedures
+
+6. **Performance Standards** (`performance.md`)
+   - Load time requirements
+   - Memory usage limits
+   - Optimization techniques
+   - Caching strategies
+   - Monitoring and profiling
+
+7. **Deployment Workflow** (`deployment.md`)
+   - CI/CD pipeline stages
+   - Environment configurations
+   - Release procedures
+   - Rollback strategies
+   - Health check requirements
+
+## Inclusion Mode Selection
+
+Ask the user to specify the inclusion mode for the custom steering document:
+
+### 1. Always Included (Default)
+- Loaded in every AI interaction
+- Best for: Universal standards that apply to all code
+- Example: Security policies, general code style
+
+### 2. Conditional Inclusion
+- Loaded only when working with matching files
+- Specify patterns like: `"*.test.js"`, `"src/api/**/*"`, `"**/auth/*"`
+- Best for: Context-specific guidelines
+- Example: Test conventions only when editing test files
+
+### 3. Manual Inclusion
+- Only loaded when explicitly referenced with `#filename`
+- Best for: Specialized, occasionally-needed context
+- Example: Migration guides, complex architectural decisions
+
+## Document Structure Guidelines
+
+Create the custom steering document with:
+
+1. **Clear Title and Purpose**
+   - What aspect of the project this document covers
+   - When this guidance should be applied
+
+2. **Specific Guidelines**
+   - Concrete rules and patterns to follow
+   - Rationale for important decisions
+
+3. **Code Examples**
+   - Show correct implementation patterns
+   - Include counter-examples if helpful
+
+4. **Integration Points**
+   - How this relates to other steering documents
+   - Dependencies or prerequisites
+
+## Instructions
+
+1. **Ask the user** for:
+   - Document name (descriptive filename ending in .md)
+   - Topic/purpose of the custom steering
+   - Inclusion mode preference
+   - Specific patterns for conditional inclusion (if applicable)
+
+2. **Create the document** in `.kiro/steering/` with:
+   - Clear, focused content (2-3 minute read)
+   - Practical examples
+   - Consistent formatting with other steering files
+
+3. **Document the inclusion mode** by adding a comment at the top:
+   ```markdown
+   <!-- Inclusion Mode: Always | Conditional: "pattern" | Manual -->
+   ```
+
+4. **Validate** that the document:
+   - Doesn't duplicate existing steering content
+   - Provides unique value for the specified context
+   - Follows markdown best practices
+
+Remember: Custom steering documents should supplement, not replace, the foundational three files. They provide specialized context for specific aspects of your project.

--- a/.claude/commands/steering-init.md
+++ b/.claude/commands/steering-init.md
@@ -1,0 +1,71 @@
+---
+description: Initialize Kiro steering documents for persistent project knowledge
+allowed-tools: Bash, Read, Write, Edit, MultiEdit, Glob, Grep, LS
+---
+
+# Kiro Steering Initialization
+
+Create foundational steering documents in `.kiro/steering/` to establish consistent project standards and conventions that will guide AI interactions throughout spec-driven development.
+
+## Project Analysis
+
+### Current Project Structure
+- Project files: !`find . -type f -name "*.py" -o -name "*.js" -o -name "*.ts" -o -name "*.jsx" -o -name "*.tsx" -o -name "*.java" -o -name "*.go" -o -name "*.rs" | grep -v node_modules | grep -v .git | grep -v dist | head -30`
+- Configuration files: !`find . -maxdepth 3 -name "package.json" -o -name "requirements.txt" -o -name "pom.xml" -o -name "Cargo.toml" -o -name "go.mod" -o -name "pyproject.toml" -o -name "tsconfig.json"`
+- Documentation: !`find . -maxdepth 3 -name "README*" -o -name "CHANGELOG*" -o -name "LICENSE*" -o -name "*.md" | grep -v node_modules | grep -v .git`
+
+### Existing Documentation
+- Main README: @README.md
+- Package configuration: @package.json
+- Python requirements: @requirements.txt
+- TypeScript config: @tsconfig.json
+- Project documentation: @docs/
+
+## Task: Generate Kiro Steering Documents
+
+Create the three foundational steering documents that provide persistent knowledge about your project:
+
+### 1. Product Overview (`product.md`)
+Generate a comprehensive product overview that includes:
+- **Product Overview**: Brief description of what the product is
+- **Core Features**: Bulleted list of main capabilities
+- **Target Use Case**: Specific scenarios the product addresses
+- **Key Value Proposition**: Unique benefits and differentiators
+
+This helps AI understand the context for technical decisions and business requirements.
+
+### 2. Technology Stack (`tech.md`)
+Document the complete technology landscape:
+- **Architecture**: High-level system design (monolith, microservices, etc.)
+- **Frontend**: Frameworks, libraries, build tools (if applicable)
+- **Backend**: Language, framework, server technology (if applicable)
+- **Development Environment**: Required tools and setup
+- **Common Commands**: Frequently used development commands
+- **Environment Variables**: Key configuration variables
+- **Port Configuration**: Standard ports used by services
+
+This guides AI to prefer established technology choices and patterns.
+
+### 3. Project Structure (`structure.md`)
+Outline the codebase organization:
+- **Root Directory Organization**: Top-level structure with descriptions
+- **Subdirectory Structures**: Detailed breakdown of key directories
+- **Code Organization Patterns**: How code is structured (MVC, domain-driven, etc.)
+- **File Naming Conventions**: Standards for naming files and directories
+- **Import Organization**: How imports/dependencies are organized
+- **Key Architectural Principles**: Core design decisions and patterns
+
+This ensures generated code fits seamlessly into the existing codebase.
+
+## Instructions
+
+1. **Create `.kiro/steering/` directory** if it doesn't exist
+2. **Analyze the codebase thoroughly** to understand current patterns and architecture
+3. **Generate comprehensive but focused documents** - each file should be readable in 2-3 minutes
+4. **Use clear markdown formatting** with proper headers and sections
+5. **Include concrete examples** where helpful for understanding
+6. **Focus on facts over assumptions** - document what exists, not what might be ideal
+7. **Follow spec-driven development principles** - these documents will guide future specifications
+
+The goal is to create a solid foundation of project knowledge that will make all future AI interactions more consistent and aligned with your project's standards, enabling effective spec-driven development.
+ultrathink

--- a/.claude/commands/steering-update.md
+++ b/.claude/commands/steering-update.md
@@ -1,0 +1,100 @@
+---
+description: Update Kiro steering documents based on recent project changes
+allowed-tools: Bash, Read, Write, Edit, MultiEdit, Glob, Grep, LS
+---
+
+# Kiro Steering Update
+
+Update existing steering documents in `.kiro/steering/` to reflect recent project changes and maintain accurate project knowledge for ongoing spec-driven development.
+
+## Change Analysis
+
+### Recent Git Activity
+- Recent commits: !`git log --oneline -15`
+- Modified files (last 10 commits): !`git diff --name-only HEAD~10`
+- Added files: !`git diff --name-status HEAD~10 | grep "^A"`
+- Deleted files: !`git diff --name-status HEAD~10 | grep "^D"`
+- Renamed files: !`git diff --name-status HEAD~10 | grep "^R"`
+
+### Dependency Changes
+- Package.json changes: !`git diff HEAD~10 -- package.json 2>/dev/null || echo "No package.json changes"`
+- Requirements.txt changes: !`git diff HEAD~10 -- requirements.txt 2>/dev/null || echo "No requirements.txt changes"`
+- Config changes: !`git diff HEAD~10 --name-only | grep -E "(tsconfig|webpack|vite|rollup|babel|eslint|prettier)"`
+
+### Current Project State
+- Current structure: !`find . -type f -name "*.py" -o -name "*.js" -o -name "*.ts" -o -name "*.jsx" -o -name "*.tsx" -o -name "*.java" -o -name "*.go" -o -name "*.rs" | grep -v node_modules | grep -v .git | grep -v dist | head -30`
+- Dependencies: !`find . -maxdepth 3 -name "package.json" -o -name "requirements.txt" -o -name "pom.xml" -o -name "Cargo.toml" -o -name "go.mod" -o -name "pyproject.toml" -o -name "tsconfig.json"`
+
+## Current Steering Documents
+
+### Load Existing Steering Context
+- Product overview: @.kiro/steering/product.md
+- Technology stack: @.kiro/steering/tech.md
+- Project structure: @.kiro/steering/structure.md
+- Custom steering files: !`find .kiro/steering -name "*.md" | grep -v -E "(product|tech|structure).md" || echo "No custom steering files found"`
+
+## Task: Update Steering Documents
+
+Analyze recent changes and update the steering documents to maintain accuracy:
+
+### 1. Update Product Overview (`product.md`)
+Review and update if there are:
+- **New features** added to the product
+- **Removed features** or deprecated functionality
+- **Changed use cases** or target audience
+- **Updated value propositions** or benefits
+- **Modified product goals** or roadmap items
+
+Only update sections that have actually changed.
+
+### 2. Update Technology Stack (`tech.md`)
+Check for changes in:
+- **New dependencies** added via package managers
+- **Removed libraries** or frameworks
+- **Version upgrades** of major dependencies
+- **New development tools** or build processes
+- **Changed environment variables** or configuration
+- **Modified port assignments** or service architecture
+- **Updated common commands** or scripts
+
+Focus on significant technology changes, not minor version bumps.
+
+### 3. Update Project Structure (`structure.md`)
+Look for changes in:
+- **New directories** or major reorganization
+- **Changed file organization** patterns
+- **New or modified naming conventions**
+- **Updated architectural patterns** or principles
+- **Refactored code structure** or module boundaries
+- **Changed import patterns** or dependencies
+
+Update only if there are meaningful structural changes.
+
+### 4. Review Custom Steering Files
+If custom steering files exist:
+- Check if they're still relevant to current project state
+- Update content based on recent changes
+- Remove if no longer applicable
+- Note any new areas that might need custom steering
+
+## Instructions
+
+1. **Analyze the git history** to understand what has changed
+2. **Compare current state** with existing steering documents
+3. **Update only what has changed** - don't rewrite unchanged sections
+4. **Preserve existing structure** and formatting consistency
+5. **Add new sections** only if there are significant new areas
+6. **Mark deprecated content** rather than deleting (unless completely removed)
+7. **Include dates** for major changes if helpful for context
+8. **Maintain spec-driven development alignment** - ensure changes support future specifications
+
+## Best Practices
+
+- **Keep changes focused** - steering should remain concise and readable
+- **Maintain consistency** with existing document style and format
+- **Explain reasoning** for significant changes or architectural decisions
+- **Provide examples** for new patterns or conventions
+- **Regular maintenance** - run this after major features or refactoring
+- **Version awareness** - consider backward compatibility when updating
+
+The goal is to keep steering documents current without unnecessary churn, ensuring they continue to provide accurate guidance for AI interactions and support effective spec-driven development.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,3 +50,128 @@ AI運用原則
 ## 必ず守ってもらいたいこと
 
 レビュー観点一覧を参照して、必ず裏付けを取ったうえで一般的な言い回しか確認すること。
+
+# Claude Code Spec-Driven Development
+
+This project implements Kiro-style Spec-Driven Development for Claude Code using hooks and slash commands.
+
+## Project Context
+
+### Project Steering
+- Product overview: `.kiro/steering/product.md`
+- Technology stack: `.kiro/steering/tech.md`
+- Project structure: `.kiro/steering/structure.md`
+- Custom steering docs for specialized contexts
+
+### Active Specifications
+- Current spec: Check `.kiro/specs/` for active specifications
+- Use `/spec-status [feature-name]` to check progress
+
+## Development Guidelines
+- Think in English, but generate responses in Japanese (思考は英語、回答の生成は日本語で行うように)
+
+## Spec-Driven Development Workflow
+
+### Phase 0: Steering Generation (Recommended)
+
+#### Kiro Steering (`.kiro/steering/`)
+```
+/steering-init          # Generate initial steering documents
+/steering-update        # Update steering after changes
+/steering-custom        # Create custom steering for specialized contexts
+```
+
+**Note**: For new features or empty projects, steering is recommended but not required. You can proceed directly to spec-requirements if needed.
+
+### Phase 1: Specification Creation
+```
+/spec-init [feature-name]           # Initialize spec structure only
+/spec-requirements [feature-name]   # Generate requirements → Review → Edit if needed
+/spec-design [feature-name]         # Generate technical design → Review → Edit if needed
+/spec-tasks [feature-name]          # Generate implementation tasks → Review → Edit if needed
+```
+
+### Phase 2: Progress Tracking
+```
+/spec-status [feature-name]         # Check current progress and phases
+```
+
+## Spec-Driven Development Workflow
+
+Kiro's spec-driven development follows a strict **3-phase approval workflow**:
+
+### Phase 1: Requirements Generation & Approval
+1. **Generate**: `/spec-requirements [feature-name]` - Generate requirements document
+2. **Review**: Human reviews `requirements.md` and edits if needed
+3. **Approve**: Manually update `spec.json` to set `"requirements": true`
+
+### Phase 2: Design Generation & Approval
+1. **Generate**: `/spec-design [feature-name]` - Generate technical design (requires requirements approval)
+2. **Review**: Human reviews `design.md` and edits if needed
+3. **Approve**: Manually update `spec.json` to set `"design": true`
+
+### Phase 3: Tasks Generation & Approval
+1. **Generate**: `/spec-tasks [feature-name]` - Generate implementation tasks (requires design approval)
+2. **Review**: Human reviews `tasks.md` and edits if needed
+3. **Approve**: Manually update `spec.json` to set `"tasks": true`
+
+### Implementation
+Only after all three phases are approved can implementation begin.
+
+**Key Principle**: Each phase requires explicit human approval before proceeding to the next phase, ensuring quality and accuracy throughout the development process.
+
+## Development Rules
+
+1. **Consider steering**: Run `/steering-init` before major development (optional for new features)
+2. **Follow the 3-phase approval workflow**: Requirements → Design → Tasks → Implementation
+3. **Manual approval required**: Each phase must be explicitly approved by human review
+4. **No skipping phases**: Design requires approved requirements; Tasks require approved design
+5. **Update task status**: Mark tasks as completed when working on them
+6. **Keep steering current**: Run `/steering-update` after significant changes
+7. **Check spec compliance**: Use `/spec-status` to verify alignment
+
+## Automation
+
+This project uses Claude Code hooks to:
+- Automatically track task progress in tasks.md
+- Check spec compliance
+- Preserve context during compaction
+- Detect steering drift
+
+### Task Progress Tracking
+
+When working on implementation:
+1. **Manual tracking**: Update tasks.md checkboxes manually as you complete tasks
+2. **Progress monitoring**: Use `/spec-status` to view current completion status
+3. **TodoWrite integration**: Use TodoWrite tool to track active work items
+4. **Status visibility**: Checkbox parsing shows completion percentage
+
+## Getting Started
+
+1. Initialize steering documents: `/steering-init`
+2. Create your first spec: `/spec-init [your-feature-name]`
+3. Follow the workflow through requirements, design, and tasks
+
+## Kiro Steering Details
+
+Kiro-style steering provides persistent project knowledge through markdown files:
+
+### Core Steering Documents
+- **product.md**: Product overview, features, use cases, value proposition
+- **tech.md**: Architecture, tech stack, dev environment, commands, ports
+- **structure.md**: Directory organization, code patterns, naming conventions
+
+### Custom Steering
+Create specialized steering documents for:
+- API standards
+- Testing approaches
+- Code style guidelines
+- Security policies
+- Database conventions
+- Performance standards
+- Deployment workflows
+
+### Inclusion Modes
+- **Always Included**: Loaded in every interaction (default)
+- **Conditional**: Loaded for specific file patterns (e.g., `"*.test.js"`)
+- **Manual**: Loaded on-demand with `#filename` reference


### PR DESCRIPTION
## タイトル
Claude用Spec-Driven Developmentコマンド群の追加

## 説明
- `.claude/commands/` ディレクトリに、Spec-Driven Developmentを実現するためのコマンド仕様（spec-init, spec-requirements, spec-design, spec-tasks, spec-status など）を追加しました。
- CLAUDE.mdに、KiroスタイルのSpec-Driven Developmentワークフローや運用ルール、コマンドの概要を追記しました。
- コマンドごとに詳細な説明・利用手順・フォーマット例・レビュープロセスなどを記載しています。
- プロジェクトの仕様策定・設計・タスク分割・進捗管理をAIと連携して進められる土台を整えました。

### 目的
Claudeと連携した高品質な仕様駆動開発をプロジェクト標準とし、要件定義から設計・実装・進捗管理まで一貫したワークフローを実現します。

ご確認のほど、よろしくお願いいたします。