### PR TITLE
問題作成とParticipant Portalでの実行を区別する

### DIFF
--- a/books/cloud-competition/chapter13.md
+++ b/books/cloud-competition/chapter13.md
@@ -29,7 +29,7 @@ TenkaCloud Liteは、これらのマルチテナント管理を持ちません�
 | TenkaCloud Lite | 自分でイベントを開く運営者 | 固定された1つ | イベントごとにデプロイして撤去する |
 | SaaS構成 | 複数組織へサービスを提供する運営者 | 複数 | 常設し、利用組織を追加して管理する |
 
-TenkaCloud Liteは、Application Admin ConsoleとParticipant Portalを含む2つの本体stackで構成します。SaaS向けのControl PlaneやCodePipelineは作りません。この設計判断は、[Lite modeのADR](https://github.com/susumutomita/TenkaCloud/blob/main/docs/architecture/adr-016-lite-mode-single-tenant.html)で確認できます。
+TenkaCloud Liteは、Application Admin ConsoleとParticipant Portalを含む2つの本体stackで構成します。SaaS向けのControl PlaneやCodePipelineは作りません。
 
 ## デプロイ前に費用と終了方法を確認する
 

--- a/books/cloud-competition/local-problem-runtime.md
+++ b/books/cloud-competition/local-problem-runtime.md
@@ -160,36 +160,35 @@ const verify = createServer(async (request, response) => {
 
 不正解時に、期待したflagや比較結果の詳細を返してはいけません。参加者が推測に使えない結果だけを返します。
 
-## TenkaCloudのチェックアウトで動かす
+## 完成した問題をParticipant Portalで動かす
 
-ローカルモードはTenkaCloud本体のParticipant Portalと採点APIを使います。問題カタログは、TenkaCloudリポジトリの`problems/` submoduleとして読み込まれます。
+問題を作成するリポジトリと、参加者が問題を解く画面を動かすリポジトリは別です。
 
-最初にTenkaCloudを準備します。
+| リポジトリ | この章での役割 |
+| --- | --- |
+| TenkaCloudChallenge | `sqli-demo`の問題文、Docker環境、採点方法を作成して検証する |
+| TenkaCloud | Participant Portal、ローカル採点API、問題コンテナを起動する |
+
+ここまで編集してきたTenkaCloudChallengeで、問題カタログの完了条件を実行します。
 
 ```bash
+make agent-gate
+```
+
+次に、TenkaCloudChallengeとは別のディレクトリへTenkaCloudを取得します。
+
+```bash
+cd ..
 git clone https://github.com/susumutomita/TenkaCloud.git
 cd TenkaCloud
 make local-onboard
 ```
 
-問題を作るときは、`problems/`の中でTenkaCloudChallengeのbranchを作ります。
+TenkaCloudは、公開されている問題カタログを`problems/`というGit submoduleから読み込みます。これはTenkaCloudChallengeを参照するための仕組みであり、TenkaCloud本体へ問題を追加するという意味ではありません。
+
+本書で作った`sqli-demo`の完成形は、すでにTenkaCloudChallengeの`main`へ公開されています。TenkaCloud側で作問用branchを作る必要はありません。問題IDを指定して、公開済みの完成形を起動します。
 
 ```bash
-cd problems
-git checkout -b feat/my-local-problem
-```
-
-本章の構成で問題ファイルを作成したら、問題カタログの完了条件を実行します。
-
-```bash
-make install
-make agent-gate
-```
-
-TenkaCloudのルートへ戻り、問題IDを指定してローカルモードを起動します。
-
-```bash
-cd ..
 make local PROBLEM=sqli-demo
 ```
 


### PR DESCRIPTION
## 変更内容

- 『TenkaCloudのチェックアウトで動かす』という不明瞭な見出しを削除
- 問題作成は独立したTenkaCloudChallengeで行うことを明記
- TenkaCloudはParticipant Portal、採点API、問題コンテナの起動に使うことを明記
- TenkaCloudのproblems配下で作問用branchを作る誤った手順を削除
- 本書では公開済みのsqli-demoを問題IDで起動する流れに修正
- 本文の理解に不要なLite mode ADRへの誘導を削除

## 確認

- make before_commit
- node scripts/validate-mermaid.mjs books/cloud-competition
- git diff --check